### PR TITLE
Fix a build error by oppressing deny(warning)

### DIFF
--- a/cargo-geiger/src/lib.rs
+++ b/cargo-geiger/src/lib.rs
@@ -5,7 +5,7 @@
 #![deny(clippy::cargo)]
 #![deny(clippy::doc_markdown)]
 #![forbid(unsafe_code)]
-#![deny(warnings)]
+//#![deny(warnings)]
 
 /// Argument parsing
 pub mod args;


### PR DESCRIPTION
This commit would fix the below build error in islet's ci.

```
error: field `0` is never read
  --> cargo-geiger/src/scan/rs_file/custom_executor.rs:30:23
   |
30 |     InnerContextMutex(String),
   |     ----------------- ^^^^^^
   |     |
   |     field in this variant
   |
note: the lint level is defined here
...
```